### PR TITLE
I408 allow report reviewers to view unpublished reports

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/ActionContext.kt
@@ -1,11 +1,14 @@
 package org.vaccineimpact.reporting_api
 
 import org.pac4j.core.profile.CommonProfile
+import org.vaccineimpact.api.models.permissions.PermissionSet
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import spark.Response
 
 interface ActionContext
 {
     val userProfile: CommonProfile
+    val permissions: PermissionSet
 
     fun contentType(): String
     fun queryParams(key: String): String?
@@ -13,6 +16,9 @@ interface ActionContext
     fun params(key: String): String
     fun addResponseHeader(key: String, value: String): Unit
     fun addDefaultResponseHeaders(contentType: String)
+
+    fun hasPermission(requirement: ReifiedPermission): Boolean
+    fun requirePermission(requirement: ReifiedPermission): Unit
 
     fun getSparkResponse(): Response
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/ActionContext.kt
@@ -18,7 +18,6 @@ interface ActionContext
     fun addDefaultResponseHeaders(contentType: String)
 
     fun hasPermission(requirement: ReifiedPermission): Boolean
-    fun requirePermission(requirement: ReifiedPermission): Unit
 
     fun getSparkResponse(): Response
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/DirectActionContext.kt
@@ -45,14 +45,6 @@ open class DirectActionContext(private val context: SparkWebContext) : ActionCon
     override fun hasPermission(requirement: ReifiedPermission)
             = permissions.any { requirement.satisfiedBy(it) }
 
-    override fun requirePermission(requirement: ReifiedPermission)
-    {
-        if (!hasPermission(requirement))
-        {
-            throw MissingRequiredPermissionError(setOf(requirement.toString()))
-        }
-    }
-
     override fun getSparkResponse(): Response
     {
         return response

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
@@ -1,5 +1,7 @@
 package org.vaccineimpact.reporting_api
 
+import org.vaccineimpact.api.models.Scope
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import spark.Filter
 import spark.Request
 import spark.Response
@@ -34,4 +36,9 @@ class DefaultHeadersFilter(val contentType: String) : Filter
     {
         addDefaultResponseHeaders(response.raw(), contentType)
     }
+}
+
+fun isReviewer(context: ActionContext): Boolean
+{
+    return context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
@@ -37,8 +37,3 @@ class DefaultHeadersFilter(val contentType: String) : Filter
         addDefaultResponseHeaders(response.raw(), contentType)
     }
 }
-
-fun isReviewer(context: ActionContext): Boolean
-{
-    return context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
-}

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
@@ -1,7 +1,5 @@
 package org.vaccineimpact.reporting_api
 
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import spark.Filter
 import spark.Request
 import spark.Response

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Router.kt
@@ -10,7 +10,6 @@ import org.vaccineimpact.reporting_api.errors.UnsupportedValueException
 import spark.Route
 import spark.Spark
 import spark.route.HttpMethod
-import javax.swing.Action
 
 class Router(val config: RouteConfig)
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ArtefactController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ArtefactController.kt
@@ -1,26 +1,27 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
-import org.vaccineimpact.reporting_api.ActionContext
-import org.vaccineimpact.reporting_api.ContentTypes
-import org.vaccineimpact.reporting_api.FileSystem
-import org.vaccineimpact.reporting_api.Files
+import org.vaccineimpact.reporting_api.*
 import org.vaccineimpact.reporting_api.db.Config
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.db.OrderlyClient
 import org.vaccineimpact.reporting_api.errors.OrderlyFileNotFoundError
 
-class ArtefactController(orderlyClient: OrderlyClient? = null, fileServer: FileSystem? = null) : Controller
-{
-    val orderly = orderlyClient ?: Orderly()
-    val files = fileServer ?: Files()
+class ArtefactController(context: ActionContext,
+                         val orderly: OrderlyClient,
+                         val files: FileSystem)
 
-    fun get(context: ActionContext): JsonObject
+    : Controller(context)
+{
+    constructor(context: ActionContext) :
+            this(context, Orderly(context), Files())
+
+    fun get(): JsonObject
     {
         return orderly.getArtefacts(context.params(":name"), context.params(":version"))
     }
 
-    fun download(context: ActionContext): Boolean
+    fun download(): Boolean
     {
         val name = context.params(":name")
         val version = context.params(":version")

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ArtefactController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ArtefactController.kt
@@ -1,6 +1,8 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
+import org.vaccineimpact.api.models.Scope
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.reporting_api.*
 import org.vaccineimpact.reporting_api.db.Config
 import org.vaccineimpact.reporting_api.db.Orderly
@@ -14,7 +16,7 @@ class ArtefactController(context: ActionContext,
     : Controller(context)
 {
     constructor(context: ActionContext) :
-            this(context, Orderly(context), Files())
+            this(context, Orderly(context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))), Files())
 
     fun get(): JsonObject
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/Controller.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/Controller.kt
@@ -1,6 +1,9 @@
 package org.vaccineimpact.reporting_api.controllers
 
-interface Controller
+import org.vaccineimpact.reporting_api.ActionContext
+
+
+abstract class Controller(val context: ActionContext)
 {
 
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/DataController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/DataController.kt
@@ -1,6 +1,8 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
+import org.vaccineimpact.api.models.Scope
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.ContentTypes
 import org.vaccineimpact.reporting_api.FileSystem
@@ -15,7 +17,7 @@ class DataController(context: ActionContext,
                      val files: FileSystem) : Controller(context)
 {
     constructor(context: ActionContext) :
-            this(context, Orderly(context), Files())
+            this(context, Orderly(context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))), Files())
 
     fun get(): JsonObject
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/DataController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/DataController.kt
@@ -10,33 +10,35 @@ import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.db.OrderlyClient
 import org.vaccineimpact.reporting_api.errors.OrderlyFileNotFoundError
 
-class DataController(orderly: OrderlyClient? = null, files: FileSystem? = null) : Controller
+class DataController(context: ActionContext,
+                     val orderly: OrderlyClient,
+                     val files: FileSystem) : Controller(context)
 {
-    val files = files ?: Files()
-    val orderly = orderly ?: Orderly()
+    constructor(context: ActionContext) :
+            this(context, Orderly(context), Files())
 
-    fun get(context: ActionContext): JsonObject
+    fun get(): JsonObject
     {
         return orderly.getData(context.params(":name"), context.params(":version"))
     }
 
-    fun downloadCSV(context: ActionContext): Boolean
+    fun downloadCSV(): Boolean
     {
         val id = context.params(":id")
         val absoluteFilePath = "${Config["orderly.root"]}data/csv/$id.csv"
 
-        return downloadFile(absoluteFilePath, "$id.csv", context, ContentTypes.csv)
+        return downloadFile(absoluteFilePath, "$id.csv", ContentTypes.csv)
     }
 
-    fun downloadRDS(context: ActionContext): Boolean
+    fun downloadRDS(): Boolean
     {
         val id = context.params(":id")
         val absoluteFilePath = "${Config["orderly.root"]}data/rds/$id.rds"
 
-        return downloadFile(absoluteFilePath, "$id.rds", context, ContentTypes.binarydata)
+        return downloadFile(absoluteFilePath, "$id.rds", ContentTypes.binarydata)
     }
 
-    fun downloadData(context: ActionContext): Boolean
+    fun downloadData(): Boolean
     {
         val name = context.params(":name")
         val version = context.params(":version")
@@ -60,11 +62,10 @@ class DataController(orderly: OrderlyClient? = null, files: FileSystem? = null) 
            ContentTypes.binarydata
         }
 
-        return downloadFile(absoluteFilePath, "$hash.$type", context, contentType)
+        return downloadFile(absoluteFilePath, "$hash.$type", contentType)
     }
 
     private fun downloadFile(absoluteFilePath: String, filename: String,
-                             context: ActionContext,
                              contentType: String): Boolean
     {
         if (!files.fileExists(absoluteFilePath))

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/HomeController.kt
@@ -4,10 +4,10 @@ import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.app_start.Router
 import org.vaccineimpact.reporting_api.db.Config
 
-class HomeController(
-) : Controller
+class HomeController(context: ActionContext)
+    : Controller(context)
 {
-    fun index(context: ActionContext) = Index("montagu-reports", Config["app.version"], Router.urls)
+    fun index() = Index("montagu-reports", Config["app.version"], Router.urls)
 
     data class Index(val name: String, val version: String, val endpoints: List<String>)
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/OnetimeTokenController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/OnetimeTokenController.kt
@@ -7,11 +7,12 @@ import org.vaccineimpact.reporting_api.security.MontaguUser
 import org.vaccineimpact.reporting_api.security.OnetimeTokenStore
 import org.vaccineimpact.reporting_api.security.WebTokenHelper
 
-class OnetimeTokenController(tokenStore: OnetimeTokenStore? = null) : Controller
+class OnetimeTokenController(context: ActionContext,
+                             val tokenStore: OnetimeTokenStore) : Controller(context)
 {
-    val tokenStore = tokenStore ?: TokenStore.instance
+    constructor(context: ActionContext): this(context, TokenStore.instance)
 
-    fun get(context: ActionContext): String
+    fun get(): String
     {
         val url = context.queryParams("url")
                 ?: throw MissingParameterError("url")

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
@@ -1,6 +1,8 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
+import org.vaccineimpact.api.models.Scope
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.ContentTypes
 import org.vaccineimpact.reporting_api.Zip
@@ -14,7 +16,7 @@ class ReportController(context: ActionContext,
                        val zip: ZipClient) : Controller(context)
 {
     constructor(context: ActionContext) :
-            this(context, Orderly(context), Zip())
+            this(context, Orderly(context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))), Zip())
 
     fun getAllNames(): List<String>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
@@ -9,28 +9,29 @@ import org.vaccineimpact.reporting_api.db.Config
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.db.OrderlyClient
 
-class ReportController(orderlyClient: OrderlyClient? = null, zipClient: ZipClient? = null) : Controller
+class ReportController(context: ActionContext,
+                       val orderly: OrderlyClient,
+                       val zip: ZipClient) : Controller(context)
 {
+    constructor(context: ActionContext) :
+            this(context, Orderly(context), Zip())
 
-    val orderly = orderlyClient ?: Orderly()
-    val zip = zipClient ?: Zip()
-
-    fun getAllNames(context: ActionContext): List<String>
+    fun getAllNames(): List<String>
     {
         return orderly.getAllReports()
     }
 
-    fun getVersionsByName(context: ActionContext): List<String>
+    fun getVersionsByName(): List<String>
     {
         return orderly.getReportsByName(context.params(":name"))
     }
 
-    fun getByNameAndVersion(context: ActionContext): JsonObject
+    fun getByNameAndVersion(): JsonObject
     {
         return orderly.getReportsByNameAndVersion(context.params(":name"), context.params(":version"))
     }
 
-    fun getZippedByNameAndVersion(context: ActionContext): Boolean
+    fun getZippedByNameAndVersion(): Boolean
     {
 
         val name = context.params(":name")

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
@@ -10,17 +10,19 @@ import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.db.OrderlyClient
 import org.vaccineimpact.reporting_api.errors.OrderlyFileNotFoundError
 
-class ResourceController(orderlyClient: OrderlyClient? = null, fileServer: FileSystem? = null) : Controller
+class ResourceController(context: ActionContext,
+                         val orderly: OrderlyClient,
+                         val files: FileSystem) : Controller(context)
 {
-    val orderly = orderlyClient ?: Orderly()
-    val files = fileServer ?: Files()
+    constructor(context: ActionContext) :
+            this(context, Orderly(context), Files())
 
-    fun get(context: ActionContext): JsonObject
+    fun get(): JsonObject
     {
         return orderly.getResources(context.params(":name"), context.params(":version"))
     }
 
-    fun download(context: ActionContext): Boolean
+    fun download(): Boolean
     {
         val name = context.params(":name")
         val version = context.params(":version")

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
@@ -1,6 +1,8 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
+import org.vaccineimpact.api.models.Scope
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.ContentTypes
 import org.vaccineimpact.reporting_api.FileSystem
@@ -15,7 +17,7 @@ class ResourceController(context: ActionContext,
                          val files: FileSystem) : Controller(context)
 {
     constructor(context: ActionContext) :
-            this(context, Orderly(context), Files())
+            this(context, Orderly(context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))), Files())
 
     fun get(): JsonObject
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
@@ -12,7 +12,7 @@ import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 class Orderly(context: ActionContext) : OrderlyClient
 {
 
-    private val isAdmin = context.hasPermission(ReifiedPermission("reports.read", Scope.Global()))
+    private val isAdmin = context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
     private val gsonParser = JsonParser()
 
     private val shouldInclude = ORDERLY.PUBLISHED.bitOr(isAdmin)

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
@@ -12,10 +12,10 @@ import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 class Orderly(context: ActionContext) : OrderlyClient
 {
 
-    private val isAdmin = context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
+    private val isReviewer = context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
     private val gsonParser = JsonParser()
 
-    private val shouldInclude = ORDERLY.PUBLISHED.bitOr(isAdmin)
+    private val shouldInclude = ORDERLY.PUBLISHED.bitOr(isReviewer)
 
     override fun getAllReports(): List<String>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
@@ -2,17 +2,12 @@ package org.vaccineimpact.reporting_api.db
 
 import com.google.gson.*
 import org.jooq.TableField
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
-import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Tables.ORDERLY
 import org.vaccineimpact.reporting_api.db.tables.records.OrderlyRecord
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 
-class Orderly(context: ActionContext) : OrderlyClient
+class Orderly(isReviewer: Boolean = false) : OrderlyClient
 {
-
-    private val isReviewer = context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
     private val gsonParser = JsonParser()
 
     private val shouldInclude = ORDERLY.PUBLISHED.bitOr(isReviewer)

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/OrderlyClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/OrderlyClient.kt
@@ -6,6 +6,7 @@ import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 interface OrderlyClient
 {
     fun getAllReports(): List<String>
+
     @Throws(UnknownObjectError::class)
     fun getReportsByName(name: String): List<String>
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/ArtefactTests.kt
@@ -1,8 +1,11 @@
 package org.vaccineimpact.reporting_api.tests.database_tests
 
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 import org.vaccineimpact.reporting_api.tests.insertReport
@@ -12,7 +15,11 @@ class ArtefactTests : DatabaseTests()
 
     private fun createSut(): Orderly
     {
-        return Orderly()
+        val actionContext = mock<ActionContext> {
+            on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
+        }
+
+        return Orderly(actionContext)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/ArtefactTests.kt
@@ -1,11 +1,8 @@
 package org.vaccineimpact.reporting_api.tests.database_tests
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 import org.vaccineimpact.reporting_api.tests.insertReport
@@ -15,11 +12,7 @@ class ArtefactTests : DatabaseTests()
 
     private fun createSut(): Orderly
     {
-        val actionContext = mock<ActionContext> {
-            on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
-        }
-
-        return Orderly(actionContext)
+        return Orderly(false)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/DataTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/DataTests.kt
@@ -1,8 +1,11 @@
 package org.vaccineimpact.reporting_api.tests.database_tests
 
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 import org.vaccineimpact.reporting_api.tests.insertReport
@@ -12,7 +15,11 @@ class DataTests : DatabaseTests()
 
     private fun createSut(): Orderly
     {
-        return Orderly()
+        val actionContext = mock<ActionContext> {
+            on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
+        }
+
+        return Orderly(actionContext)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/DataTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/DataTests.kt
@@ -1,11 +1,8 @@
 package org.vaccineimpact.reporting_api.tests.database_tests
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
-import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 import org.vaccineimpact.reporting_api.tests.insertReport
@@ -15,11 +12,7 @@ class DataTests : DatabaseTests()
 
     private fun createSut(): Orderly
     {
-        val actionContext = mock<ActionContext> {
-            on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
-        }
-
-        return Orderly(actionContext)
+        return Orderly(false)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyAdminTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyAdminTests.kt
@@ -16,7 +16,7 @@ class OrderlyAdminTests : DatabaseTests()
     private fun createSut(): Orderly
     {
         val actionContext = mock<ActionContext> {
-            on { this.hasPermission(ReifiedPermission("reports.read", Scope.Global())) } doReturn true
+            on { this.hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn true
         }
 
         return Orderly(actionContext)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyAdminTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyAdminTests.kt
@@ -1,0 +1,83 @@
+package org.vaccineimpact.reporting_api.tests.database_tests
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.vaccineimpact.api.models.Scope
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.reporting_api.ActionContext
+import org.vaccineimpact.reporting_api.db.Orderly
+import org.vaccineimpact.reporting_api.tests.insertReport
+
+class OrderlyAdminTests : DatabaseTests()
+{
+
+    private fun createSut(): Orderly
+    {
+        val actionContext = mock<ActionContext> {
+            on { this.hasPermission(ReifiedPermission("reports.read", Scope.Global())) } doReturn true
+        }
+
+        return Orderly(actionContext)
+    }
+
+    @Test
+    fun `can get all published and unpublished report names`()
+    {
+
+        insertReport("test", "version1")
+        insertReport("test", "version2")
+        insertReport("test2", "test2version1")
+        insertReport("test3", "test3version", published = false)
+
+        val sut = createSut()
+
+        val results = sut.getAllReports()
+
+        assertThat(results.count()).isEqualTo(3)
+        assertThat(results[0]).isEqualTo("test")
+        assertThat(results[1]).isEqualTo("test2")
+        assertThat(results[2]).isEqualTo("test3")
+    }
+
+    @Test
+    fun `can get unpublished report metadata`()
+    {
+
+        insertReport("test", "version1",
+                hashArtefacts = "{\"summary.csv\":\"07dffb00305279935544238b39d7b14b\"}", published = false)
+
+        val sut = createSut()
+
+        val result = sut.getReportsByNameAndVersion("test", "version1")
+
+        assertThat(result.has("name")).isTrue()
+        assertThat(result.has("id")).isTrue()
+
+        assertThat(result.has("hash_artefacts")).isTrue()
+        assertThat(result["hash_artefacts"].asJsonObject.has("summary.csv")).isTrue()
+    }
+
+
+    @Test
+    fun `can get all published and unpublished report versions`()
+    {
+
+        insertReport("test", "version1")
+        insertReport("test", "version2")
+        insertReport("test", "version3", published = false)
+
+        val sut = createSut()
+
+        val results = sut.getReportsByName("test")
+
+        assertThat(results.count()).isEqualTo(3)
+        assertThat(results[0]).isEqualTo("version1")
+        assertThat(results[1]).isEqualTo("version2")
+        assertThat(results[2]).isEqualTo("version3")
+
+    }
+
+
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyReviewerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyReviewerTests.kt
@@ -10,7 +10,7 @@ import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.tests.insertReport
 
-class OrderlyAdminTests : DatabaseTests()
+class OrderlyReviewerTests : DatabaseTests()
 {
 
     private fun createSut(): Orderly

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyReviewerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyReviewerTests.kt
@@ -1,12 +1,7 @@
 package org.vaccineimpact.reporting_api.tests.database_tests
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
-import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.tests.insertReport
 
@@ -15,11 +10,7 @@ class OrderlyReviewerTests : DatabaseTests()
 
     private fun createSut(): Orderly
     {
-        val actionContext = mock<ActionContext> {
-            on { this.hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn true
-        }
-
-        return Orderly(actionContext)
+        return Orderly(true)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
@@ -1,13 +1,8 @@
 package org.vaccineimpact.reporting_api.tests.database_tests
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
-import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 import org.vaccineimpact.reporting_api.tests.insertReport
@@ -17,11 +12,7 @@ class OrderlyTests : DatabaseTests()
 
     private fun createSut(): Orderly
     {
-        val actionContext = mock<ActionContext> {
-            on { this.hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn false
-        }
-
-        return Orderly(actionContext)
+        return Orderly(false)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
@@ -18,7 +18,7 @@ class OrderlyTests : DatabaseTests()
     private fun createSut(): Orderly
     {
         val actionContext = mock<ActionContext> {
-            on { this.hasPermission(ReifiedPermission("reports.read", Scope.Global())) } doReturn false
+            on { this.hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn false
         }
 
         return Orderly(actionContext)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
@@ -1,8 +1,13 @@
 package org.vaccineimpact.reporting_api.tests.database_tests
 
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import org.vaccineimpact.api.models.Scope
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 import org.vaccineimpact.reporting_api.tests.insertReport
@@ -12,7 +17,11 @@ class OrderlyTests : DatabaseTests()
 
     private fun createSut(): Orderly
     {
-        return Orderly()
+        val actionContext = mock<ActionContext> {
+            on { this.hasPermission(ReifiedPermission("reports.read", Scope.Global())) } doReturn false
+        }
+
+        return Orderly(actionContext)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
@@ -9,10 +9,8 @@ import org.vaccineimpact.reporting_api.db.Config
 import org.vaccineimpact.reporting_api.security.MontaguUser
 import org.vaccineimpact.reporting_api.tests.integration_tests.APITests
 
-class RequestHelper
-{
-    init
-    {
+class RequestHelper {
+    init {
         CertificateHelper.disableCertificateValidation()
     }
 
@@ -20,35 +18,37 @@ class RequestHelper
     private val parser = JsonParser()
 
     val fakeUser = MontaguUser("tettusername", "user", "*/reports.read")
+    val fakeReviewer = MontaguUser("testreviewer", "reports-reviewer", "*/reports.read,*/reports.review")
 
-    fun get(url: String, contentType: String = ContentTypes.json): Response
-    {
+    fun get(url: String, contentType: String = ContentTypes.json, reviewer: Boolean = false): Response {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
         )
 
-        val token = APITests.tokenHelper
-                .generateToken(fakeUser)
+        val token = if (!reviewer) {
+            APITests.tokenHelper
+                    .generateToken(fakeUser)
+        } else {
+            APITests.tokenHelper
+                    .generateToken(fakeReviewer)
+        }
 
         headers += mapOf("Authorization" to "Bearer $token")
 
         return get(baseUrl + url, headers)
     }
 
-    fun generateOnetimeToken(url: String): String
-    {
+    fun generateOnetimeToken(url: String): String {
         val response = get("/onetime_token/?url=/v1$url")
         val json = parser.parse(response.text)
-        if (json["status"].asString != "success")
-        {
+        if (json["status"].asString != "success") {
             Assertions.fail("Failed to get onetime token. Result from API was:" + response.text)
         }
         return json["data"].asString
     }
 
-    fun getWrongAuth(url: String, contentType: String = ContentTypes.json): Response
-    {
+    fun getWrongAuth(url: String, contentType: String = ContentTypes.json): Response {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
@@ -60,8 +60,7 @@ class RequestHelper
         return get(baseUrl + url, headers)
     }
 
-    fun getWrongPermissions(url: String, contentType: String = ContentTypes.json): Response
-    {
+    fun getWrongPermissions(url: String, contentType: String = ContentTypes.json): Response {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
@@ -94,8 +93,7 @@ class RequestHelper
 //        return get(baseUrl + url + "?access_token=$token", headers)
 //    }
 
-    fun getNoAuth(url: String, contentType: String = ContentTypes.json): Response
-    {
+    fun getNoAuth(url: String, contentType: String = ContentTypes.json): Response {
         val headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
@@ -9,8 +9,10 @@ import org.vaccineimpact.reporting_api.db.Config
 import org.vaccineimpact.reporting_api.security.MontaguUser
 import org.vaccineimpact.reporting_api.tests.integration_tests.APITests
 
-class RequestHelper {
-    init {
+class RequestHelper
+{
+    init
+    {
         CertificateHelper.disableCertificateValidation()
     }
 
@@ -20,16 +22,20 @@ class RequestHelper {
     val fakeUser = MontaguUser("tettusername", "user", "*/reports.read")
     val fakeReviewer = MontaguUser("testreviewer", "reports-reviewer", "*/reports.read,*/reports.review")
 
-    fun get(url: String, contentType: String = ContentTypes.json, reviewer: Boolean = false): Response {
+    fun get(url: String, contentType: String = ContentTypes.json, reviewer: Boolean = false): Response
+    {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
         )
 
-        val token = if (!reviewer) {
+        val token = if (!reviewer)
+        {
             APITests.tokenHelper
                     .generateToken(fakeUser)
-        } else {
+        }
+        else
+        {
             APITests.tokenHelper
                     .generateToken(fakeReviewer)
         }
@@ -39,16 +45,19 @@ class RequestHelper {
         return get(baseUrl + url, headers)
     }
 
-    fun generateOnetimeToken(url: String): String {
+    fun generateOnetimeToken(url: String): String
+    {
         val response = get("/onetime_token/?url=/v1$url")
         val json = parser.parse(response.text)
-        if (json["status"].asString != "success") {
+        if (json["status"].asString != "success")
+        {
             Assertions.fail("Failed to get onetime token. Result from API was:" + response.text)
         }
         return json["data"].asString
     }
 
-    fun getWrongAuth(url: String, contentType: String = ContentTypes.json): Response {
+    fun getWrongAuth(url: String, contentType: String = ContentTypes.json): Response
+    {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
@@ -60,7 +69,8 @@ class RequestHelper {
         return get(baseUrl + url, headers)
     }
 
-    fun getWrongPermissions(url: String, contentType: String = ContentTypes.json): Response {
+    fun getWrongPermissions(url: String, contentType: String = ContentTypes.json): Response
+    {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
@@ -93,7 +103,8 @@ class RequestHelper {
 //        return get(baseUrl + url + "?access_token=$token", headers)
 //    }
 
-    fun getNoAuth(url: String, contentType: String = ContentTypes.json): Response {
+    fun getNoAuth(url: String, contentType: String = ContentTypes.json): Response
+    {
         val headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
@@ -1,7 +1,10 @@
 package org.vaccineimpact.reporting_api.tests.integration_tests.tests
 
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.ContentTypes
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.security.WebTokenHelper
@@ -9,6 +12,10 @@ import org.vaccineimpact.reporting_api.tests.insertReport
 
 class ArtefactTests : IntegrationTest()
 {
+    private val actionContext = mock<ActionContext> {
+        on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
+    }
+
     @Test
     fun `gets dict of artefact names to hashes`()
     {
@@ -24,7 +31,7 @@ class ArtefactTests : IntegrationTest()
     @Test
     fun `gets artefact file with access token`()
     {
-        val publishedVersion = Orderly().getReportsByName("other")[0]
+        val publishedVersion = Orderly(actionContext).getReportsByName("other")[0]
 
         val url = "/reports/other/$publishedVersion/artefacts/graph.png/"
         val token = requestHelper.generateOnetimeToken(url)
@@ -38,7 +45,7 @@ class ArtefactTests : IntegrationTest()
     @Test
     fun `gets artefact file with bearer token`()
     {
-        val publishedVersion = Orderly().getReportsByName("other")[0]
+        val publishedVersion = Orderly(actionContext).getReportsByName("other")[0]
 
         val url = "/reports/other/$publishedVersion/artefacts/graph.png/"
         val response = requestHelper.get(url, ContentTypes.binarydata)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
@@ -12,10 +12,6 @@ import org.vaccineimpact.reporting_api.tests.insertReport
 
 class ArtefactTests : IntegrationTest()
 {
-    private val actionContext = mock<ActionContext> {
-        on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
-    }
-
     @Test
     fun `gets dict of artefact names to hashes`()
     {
@@ -31,7 +27,7 @@ class ArtefactTests : IntegrationTest()
     @Test
     fun `gets artefact file with access token`()
     {
-        val publishedVersion = Orderly(actionContext).getReportsByName("other")[0]
+        val publishedVersion = Orderly().getReportsByName("other")[0]
 
         val url = "/reports/other/$publishedVersion/artefacts/graph.png/"
         val token = requestHelper.generateOnetimeToken(url)
@@ -45,7 +41,7 @@ class ArtefactTests : IntegrationTest()
     @Test
     fun `gets artefact file with bearer token`()
     {
-        val publishedVersion = Orderly(actionContext).getReportsByName("other")[0]
+        val publishedVersion = Orderly().getReportsByName("other")[0]
 
         val url = "/reports/other/$publishedVersion/artefacts/graph.png/"
         val response = requestHelper.get(url, ContentTypes.binarydata)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
@@ -13,9 +13,6 @@ import java.net.URLEncoder
 
 class OnetimeTokenTests : IntegrationTest()
 {
-    private val actionContext = mock<ActionContext> {
-        on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
-    }
 
     @Test
     fun `gets one time token`()
@@ -33,7 +30,7 @@ class OnetimeTokenTests : IntegrationTest()
     @Test
     fun `can use one time token to authenticate`()
     {
-        val publishedVersion = Orderly(actionContext).getReportsByName("other")[0]
+        val publishedVersion = Orderly().getReportsByName("other")[0]
         val url = "/reports/other/$publishedVersion/artefacts/graph.png/"
 
         val tokenReponse = requestHelper.get("/onetime_token/?url=" + URLEncoder.encode("/v1$url", "UTF-8"))

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
@@ -1,8 +1,11 @@
 package org.vaccineimpact.reporting_api.tests.integration_tests.tests
 
 import com.github.fge.jackson.JsonLoader
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.ContentTypes
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.tests.insertReport
@@ -10,6 +13,9 @@ import java.net.URLEncoder
 
 class OnetimeTokenTests : IntegrationTest()
 {
+    private val actionContext = mock<ActionContext> {
+        on { this.hasPermission(org.vaccineimpact.api.models.permissions.ReifiedPermission("reports.read", org.vaccineimpact.api.models.Scope.Global())) } doReturn false
+    }
 
     @Test
     fun `gets one time token`()
@@ -27,7 +33,7 @@ class OnetimeTokenTests : IntegrationTest()
     @Test
     fun `can use one time token to authenticate`()
     {
-        val publishedVersion = Orderly().getReportsByName("other")[0]
+        val publishedVersion = Orderly(actionContext).getReportsByName("other")[0]
         val url = "/reports/other/$publishedVersion/artefacts/graph.png/"
 
         val tokenReponse = requestHelper.get("/onetime_token/?url=" + URLEncoder.encode("/v1$url", "UTF-8"))

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
@@ -52,6 +52,18 @@ class ReportTests : IntegrationTest()
         JSONValidator.validateAgainstSchema(response.text, "Version")
     }
 
+
+    @Test
+    fun `reviewer can get unpublished report by name and version`()
+    {
+        insertReport("testname", "testversion", published = false)
+        val response = requestHelper.get("/reports/testname/testversion", reviewer = true)
+
+        assertSuccessful(response)
+        assertJsonContentType(response)
+        JSONValidator.validateAgainstSchema(response.text, "Version")
+    }
+
     @Test
     fun `gets 404 if report version doesnt exist`()
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ArtefactControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ArtefactControllerTests.kt
@@ -34,9 +34,9 @@ class ArtefactControllerTests : ControllerTest()
             on { this.params(":version") } doReturn version
         }
 
-        val sut = ArtefactController(orderly, mock<FileSystem>())
+        val sut = ArtefactController(actionContext, orderly, mock<FileSystem>())
 
-        assertThat(sut.get(actionContext)).isEqualTo(artefacts)
+        assertThat(sut.get()).isEqualTo(artefacts)
     }
 
     @Test
@@ -61,9 +61,9 @@ class ArtefactControllerTests : ControllerTest()
             on { this.fileExists("${Config["orderly.root"]}archive/$name/$version/$artefact") } doReturn true
         }
 
-        val sut = ArtefactController(orderly, fileSystem)
+        val sut = ArtefactController(actionContext, orderly, fileSystem)
 
-        sut.download(actionContext)
+        sut.download()
     }
 
     @Test
@@ -83,9 +83,9 @@ class ArtefactControllerTests : ControllerTest()
             on { this.params(":artefact") } doReturn artefact
         }
 
-        val sut = ArtefactController(orderly, mock<FileSystem>())
+        val sut = ArtefactController(actionContext, orderly, mock<FileSystem>())
 
-        assertThatThrownBy { sut.download(actionContext) }
+        assertThatThrownBy { sut.download() }
                 .isInstanceOf(UnknownObjectError::class.java)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/DataControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/DataControllerTests.kt
@@ -35,9 +35,9 @@ class DataControllerTests : ControllerTest()
             on { this.params(":version") } doReturn version
         }
 
-        val sut = DataController(orderly, mock<FileSystem>())
+        val sut = DataController(actionContext, orderly, mock<FileSystem>())
 
-        assertThat(sut.get(actionContext)).isEqualTo(data)
+        assertThat(sut.get()).isEqualTo(data)
     }
 
     @Test
@@ -64,8 +64,8 @@ class DataControllerTests : ControllerTest()
             on { this.getSparkResponse() } doReturn mockSparkResponse
         }
 
-        val sut = DataController(orderly, fileSystem)
-        sut.downloadData(actionContext)
+        val sut = DataController(actionContext, orderly, fileSystem)
+        sut.downloadData()
 
         verify(fileSystem, times(1)).writeFileToOutputStream("${Config["orderly.root"]}data/csv/$hash.csv", mockOutputStream)
     }
@@ -95,8 +95,8 @@ class DataControllerTests : ControllerTest()
             on { this.queryParams("type") } doReturn "rds"
         }
 
-        val sut = DataController(orderly, fileSystem)
-        sut.downloadData(actionContext)
+        val sut = DataController(actionContext, orderly, fileSystem)
+        sut.downloadData()
 
         verify(fileSystem, times(1)).writeFileToOutputStream("${Config["orderly.root"]}data/rds/$hash.rds", mockOutputStream)
     }
@@ -116,8 +116,8 @@ class DataControllerTests : ControllerTest()
             on { this.params(":id") } doReturn hash
         }
 
-        val sut = DataController(mock<OrderlyClient>(), fileSystem)
-        sut.downloadCSV(actionContext)
+        val sut = DataController(actionContext, mock<OrderlyClient>(), fileSystem)
+        sut.downloadCSV()
 
         verify(fileSystem, times(1)).writeFileToOutputStream("${Config["orderly.root"]}data/csv/$hash.csv", mockOutputStream)
     }
@@ -137,8 +137,8 @@ class DataControllerTests : ControllerTest()
             on { this.params(":id") } doReturn hash
         }
 
-        val sut = DataController(mock<OrderlyClient>(), fileSystem)
-        sut.downloadRDS(actionContext)
+        val sut = DataController(actionContext, mock<OrderlyClient>(), fileSystem)
+        sut.downloadRDS()
 
         verify(fileSystem, times(1)).writeFileToOutputStream("${Config["orderly.root"]}data/rds/$hash.rds", mockOutputStream)
     }
@@ -160,9 +160,9 @@ class DataControllerTests : ControllerTest()
             on { this.params(":version") } doReturn version
         }
 
-        val sut = DataController(orderly, mock<FileSystem>())
+        val sut = DataController(actionContext, orderly, mock<FileSystem>())
 
-        assertThat(sut.get(actionContext)).isEqualTo(data)
+        assertThat(sut.get()).isEqualTo(data)
     }
 
     @Test
@@ -184,9 +184,9 @@ class DataControllerTests : ControllerTest()
             on { this.getSparkResponse() } doReturn mockSparkResponse
         }
 
-        val sut = DataController(orderly, mock<FileSystem>())
+        val sut = DataController(actionContext, orderly, mock<FileSystem>())
 
-        assertThatThrownBy { sut.downloadData(actionContext) }
+        assertThatThrownBy { sut.downloadData() }
                 .isInstanceOf(OrderlyFileNotFoundError::class.java)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
@@ -24,9 +24,9 @@ class ReportControllerTests : ControllerTest()
         val orderly = mock<OrderlyClient> {
             on { this.getAllReports() } doReturn reportNames
         }
-        val sut = ReportController(orderly)
+        val sut = ReportController(mock<ActionContext>(), orderly, mock<ZipClient>())
 
-        assertThat(sut.getAllNames(mock<ActionContext>())).isEqualTo(reportNames)
+        assertThat(sut.getAllNames()).isEqualTo(reportNames)
     }
 
     @Test
@@ -44,9 +44,9 @@ class ReportControllerTests : ControllerTest()
             on { this.params(":name") } doReturn reportName
         }
 
-        val sut = ReportController(orderly)
+        val sut = ReportController(actionContext, orderly, mock<ZipClient>())
 
-        assertThat(sut.getVersionsByName(actionContext)).isEqualTo(reportVersions)
+        assertThat(sut.getVersionsByName()).isEqualTo(reportVersions)
     }
 
     @Test
@@ -67,9 +67,9 @@ class ReportControllerTests : ControllerTest()
             on { this.params(":name") } doReturn reportName
         }
 
-        val sut = ReportController(orderly)
+        val sut = ReportController(actionContext, orderly, mock<ZipClient>())
 
-        assertThat(sut.getByNameAndVersion(actionContext)).isEqualTo(report)
+        assertThat(sut.getByNameAndVersion()).isEqualTo(report)
     }
 
     @Test
@@ -87,9 +87,9 @@ class ReportControllerTests : ControllerTest()
 
         val mockZipClient = mock<ZipClient>()
 
-        val sut = ReportController(mock<OrderlyClient>(), mockZipClient)
+        val sut = ReportController(actionContext, mock<OrderlyClient>(), mockZipClient)
 
-        sut.getZippedByNameAndVersion(actionContext)
+        sut.getZippedByNameAndVersion()
 
         verify(mockZipClient, times(1)).zipIt("${Config["orderly.root"]}archive/$reportName/$reportVersion/"
                 , mockOutputStream)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ResourceControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ResourceControllerTests.kt
@@ -34,9 +34,9 @@ class ResourceControllerTests : ControllerTest()
             on { this.params(":version") } doReturn version
         }
 
-        val sut = ResourceController(orderly, mock<FileSystem>())
+        val sut = ResourceController(actionContext, orderly, mock<FileSystem>())
 
-        Assertions.assertThat(sut.get(actionContext)).isEqualTo(resources)
+        Assertions.assertThat(sut.get()).isEqualTo(resources)
     }
 
     @Test
@@ -61,9 +61,9 @@ class ResourceControllerTests : ControllerTest()
             on { this.fileExists("${Config["orderly.root"]}archive/$name/$version/$resource") } doReturn true
         }
 
-        val sut = ResourceController(orderly, fileSystem)
+        val sut = ResourceController(actionContext, orderly, fileSystem)
 
-        sut.download(actionContext)
+        sut.download()
     }
 
     @Test
@@ -83,9 +83,9 @@ class ResourceControllerTests : ControllerTest()
             on { this.params(":resource") } doReturn resource
         }
 
-        val sut = ResourceController(orderly, mock<FileSystem>())
+        val sut = ResourceController(actionContext, orderly, mock<FileSystem>())
 
-        Assertions.assertThatThrownBy { sut.download(actionContext) }
+        Assertions.assertThatThrownBy { sut.download() }
                 .isInstanceOf(UnknownObjectError::class.java)
     }
 
@@ -111,9 +111,9 @@ class ResourceControllerTests : ControllerTest()
             on { this.fileExists("${Config["orderly.root"]}archive/$name/$version/$resource") } doReturn false
         }
 
-        val sut = ResourceController(orderly, fileSystem)
+        val sut = ResourceController(actionContext, orderly, fileSystem)
 
-        Assertions.assertThatThrownBy { sut.download(actionContext) }
+        Assertions.assertThatThrownBy { sut.download() }
                 .isInstanceOf(OrderlyFileNotFoundError::class.java)
     }
 


### PR DESCRIPTION
* make user permissions available in the action context
* get a new controller instance with every request, and have the controller rather than each method take a context parameter
* pass through context to Orderly, which can then filter reports according