### PR TITLE
Return more metadata in /reports/

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
+import org.vaccineimpact.api.models.Report
 import org.vaccineimpact.api.models.Scope
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.reporting_api.*
@@ -46,7 +47,7 @@ class ReportController(context: ActionContext,
         return passThroughResponse(response)
     }
 
-    fun getAllNames(): List<String>
+    fun getAllNames(): List<Report>
     {
         return orderly.getAllReports()
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
@@ -1,10 +1,15 @@
 package org.vaccineimpact.reporting_api.db
 
 import com.google.gson.*
+import org.bouncycastle.util.Times
+import org.jooq.RowN
 import org.jooq.TableField
+import org.vaccineimpact.api.models.Report
 import org.vaccineimpact.reporting_api.db.Tables.ORDERLY
 import org.vaccineimpact.reporting_api.db.tables.records.OrderlyRecord
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
+import org.jooq.impl.DSL.*
+import java.sql.Timestamp
 
 class Orderly(isReviewer: Boolean = false) : OrderlyClient
 {
@@ -12,15 +17,25 @@ class Orderly(isReviewer: Boolean = false) : OrderlyClient
 
     private val shouldInclude = ORDERLY.PUBLISHED.bitOr(isReviewer)
 
-    override fun getAllReports(): List<String>
+    override fun getAllReports(): List<Report>
     {
         JooqContext().use {
 
-            return it.dsl.select(ORDERLY.NAME)
+            val cte = "all"
+
+            val allReports = it.dsl.select(ORDERLY.NAME,
+                    ORDERLY.DATE.max().`as`("maxDate"))
                     .from(ORDERLY)
+                    .groupBy(ORDERLY.NAME)
+
+            return it.dsl.with(cte).`as`(allReports)
+                    .select(ORDERLY.NAME, ORDERLY.DISPLAYNAME, ORDERLY.ID.`as`("latestVersion"))
+                    .from(ORDERLY)
+                    .join(table(name(cte)))
+                    .on(ORDERLY.NAME.eq(field(name(cte, "name"), String::class.java))
+                            .and(ORDERLY.DATE.eq(field(name(cte, "maxDate"), Timestamp::class.java))))
                     .where(shouldInclude)
-                    .fetchInto(String::class.java)
-                    .distinct()
+                    .fetchInto(Report::class.java)
         }
 
     }
@@ -71,7 +86,7 @@ class Orderly(isReviewer: Boolean = false) : OrderlyClient
                     {
                         gsonParser.parse(valueString)
                     }
-                    catch(e: JsonParseException)
+                    catch (e: JsonParseException)
                     {
                         JsonPrimitive(valueString)
                     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
@@ -21,19 +21,19 @@ class Orderly(isReviewer: Boolean = false) : OrderlyClient
     {
         JooqContext().use {
 
-            val cte = "all"
+            val tempTable = "all"
 
             val allReports = it.dsl.select(ORDERLY.NAME,
                     ORDERLY.DATE.max().`as`("maxDate"))
                     .from(ORDERLY)
                     .groupBy(ORDERLY.NAME)
 
-            return it.dsl.with(cte).`as`(allReports)
+            return it.dsl.with(tempTable).`as`(allReports)
                     .select(ORDERLY.NAME, ORDERLY.DISPLAYNAME, ORDERLY.ID.`as`("latestVersion"))
                     .from(ORDERLY)
-                    .join(table(name(cte)))
-                    .on(ORDERLY.NAME.eq(field(name(cte, "name"), String::class.java))
-                            .and(ORDERLY.DATE.eq(field(name(cte, "maxDate"), Timestamp::class.java))))
+                    .join(table(name(tempTable)))
+                    .on(ORDERLY.NAME.eq(field(name(tempTable, "name"), String::class.java))
+                            .and(ORDERLY.DATE.eq(field(name(tempTable, "maxDate"), Timestamp::class.java))))
                     .where(shouldInclude)
                     .fetchInto(Report::class.java)
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/OrderlyClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/OrderlyClient.kt
@@ -1,11 +1,12 @@
 package org.vaccineimpact.reporting_api.db
 
 import com.google.gson.JsonObject
+import org.vaccineimpact.api.models.Report
 import org.vaccineimpact.reporting_api.errors.UnknownObjectError
 
 interface OrderlyClient
 {
-    fun getAllReports(): List<String>
+    fun getAllReports(): List<Report>
 
     @Throws(UnknownObjectError::class)
     fun getReportsByName(name: String): List<String>

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/InsertHelpers.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/InsertHelpers.kt
@@ -20,6 +20,7 @@ fun insertReport(name: String,
         val record = it.dsl.newRecord(ORDERLY)
                 .apply {
                     this.name = name
+                    this.displayname = "display name $name"
                     this.id = version
                     this.views = views
                     this.data = data

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyReviewerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyReviewerTests.kt
@@ -27,9 +27,9 @@ class OrderlyReviewerTests : DatabaseTests()
         val results = sut.getAllReports()
 
         assertThat(results.count()).isEqualTo(3)
-        assertThat(results[0]).isEqualTo("test")
-        assertThat(results[1]).isEqualTo("test2")
-        assertThat(results[2]).isEqualTo("test3")
+        assertThat(results[0].name).isEqualTo("test")
+        assertThat(results[1].name).isEqualTo("test2")
+        assertThat(results[2].name).isEqualTo("test3")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
@@ -19,9 +19,10 @@ class OrderlyTests : DatabaseTests()
     fun `can get all published report names`()
     {
 
-        insertReport("test", "version1")
-        insertReport("test", "version2")
-        insertReport("test2", "test2version1")
+        insertReport("test", "va")
+        insertReport("test", "vz")
+        insertReport("test2", "vc")
+        insertReport("test2", "vb")
         insertReport("test3", "test3version", published = false)
 
         val sut = createSut()
@@ -29,8 +30,14 @@ class OrderlyTests : DatabaseTests()
         val results = sut.getAllReports()
 
         assertThat(results.count()).isEqualTo(2)
-        assertThat(results[0]).isEqualTo("test")
-        assertThat(results[1]).isEqualTo("test2")
+
+        assertThat(results[0].name).isEqualTo("test")
+        assertThat(results[0].displayName).isEqualTo("display name test")
+        assertThat(results[0].latestVersion).isEqualTo("vz")
+
+        assertThat(results[1].name).isEqualTo("test2")
+        assertThat(results[1].displayName).isEqualTo("display name test2")
+        assertThat(results[1].latestVersion).isEqualTo("vb")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
@@ -16,7 +16,7 @@ class ReportTests : IntegrationTest()
     @Test
     fun `can get reports`()
     {
-        val response = requestHelper.get("/reports")
+        val response = requestHelper.get("/reports/")
 
         assertSuccessful(response)
         assertJsonContentType(response)
@@ -97,7 +97,7 @@ class ReportTests : IntegrationTest()
 
         assertSuccessful(response)
         assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "Report")
+        JSONValidator.validateAgainstSchema(response.text, "Versions")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
@@ -47,17 +47,17 @@ class ReportControllerTests : ControllerTest()
     @Test
     fun `getReports returns all report names`()
     {
-        val reportNames = listOf(Report("testname1", "test full name 1", "v1"),
+        val reports = listOf(Report("testname1", "test full name 1", "v1"),
                 Report("testname2", "test full name 2", "v1"))
 
         val orderly = mock<OrderlyClient> {
-            on { this.getAllReports() } doReturn reportNames
+            on { this.getAllReports() } doReturn reports
         }
         val sut = ReportController(mock<ActionContext>(), orderly, mock<ZipClient>(),
                 mock<OrderlyServerAPI>(),
                 mockConfig)
 
-        assertThat(sut.getAllNames()).isEqualTo(reportNames)
+        assertThat(sut.getAllNames()).isEqualTo(reports)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.*
 import khttp.responses.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.vaccineimpact.api.models.Report
 import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.OrderlyServerAPI
 import org.vaccineimpact.reporting_api.ZipClient
@@ -46,7 +47,8 @@ class ReportControllerTests : ControllerTest()
     @Test
     fun `getReports returns all report names`()
     {
-        val reportNames = listOf("testname1", "testname2")
+        val reportNames = listOf(Report("testname1", "test full name 1", "v1"),
+                Report("testname2", "test full name 2", "v1"))
 
         val orderly = mock<OrderlyClient> {
             on { this.getAllReports() } doReturn reportNames

--- a/src/app/src/test/resources/spec/Report.schema.json
+++ b/src/app/src/test/resources/spec/Report.schema.json
@@ -3,8 +3,8 @@
 	"type": "object",
 	"properties": {
 		"name": {"type" :"string"},
-		"id": {"type" :"string"},
-		"displayname": {"type": [ "string", "null"] },
+		"display_name": {"type": [ "string", "null"] },
 		"latest_version": { "type": "string" }
-	}
+	},
+	"required": ["name", "latest_version", "display_name"]
 }

--- a/src/app/src/test/resources/spec/Report.schema.json
+++ b/src/app/src/test/resources/spec/Report.schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "Report",
+    "id": "Report",
 	"type": "object",
 	"properties": {
 		"name": {"type" :"string"},

--- a/src/app/src/test/resources/spec/Report.schema.json
+++ b/src/app/src/test/resources/spec/Report.schema.json
@@ -1,10 +1,10 @@
 {
-    "id": "Report",
-	"type": "object",
-	"properties": {
-		"name": {"type" :"string"},
-		"display_name": {"type": [ "string", "null"] },
-		"latest_version": { "type": "string" }
-	},
-	"required": ["name", "latest_version", "display_name"]
+  "id": "Report",
+  "type": "object",
+  "properties": {
+    "name": {"type" :"string"},
+    "display_name": {"type": [ "string", "null"] },
+    "latest_version": { "type": "string" }
+  },
+  "required": ["name", "latest_version", "display_name"]
 }

--- a/src/app/src/test/resources/spec/Report.schema.json
+++ b/src/app/src/test/resources/spec/Report.schema.json
@@ -1,5 +1,10 @@
 {
 	"id": "Report",
-	"type": "array",
-	"items": { "type": "string" }
+	"type": "object",
+	"properties": {
+		"name": {"type" :"string"},
+		"id": {"type" :"string"},
+		"displayname": {"type": [ "string", "null"] },
+		"latest_version": { "type": "string" }
+	}
 }

--- a/src/app/src/test/resources/spec/Reports.schema.json
+++ b/src/app/src/test/resources/spec/Reports.schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "Report",
+	"id": "Reports",
 	"type": "array",
-	"items": { "type": "string" }
+	"items": { "$ref": "Report.schema.json" }
 }

--- a/src/app/src/test/resources/spec/Reports.schema.json
+++ b/src/app/src/test/resources/spec/Reports.schema.json
@@ -1,5 +1,5 @@
 {
 	"id": "Reports",
-	"type": "array",
+    "type": "array",
 	"items": { "$ref": "Report.schema.json" }
 }

--- a/src/app/src/test/resources/spec/Reports.schema.json
+++ b/src/app/src/test/resources/spec/Reports.schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "Reports",
-    "type": "array",
-	"items": { "$ref": "Report.schema.json" }
+  "id": "Reports",
+  "type": "array",
+  "items": { "$ref": "Report.schema.json" }
 }

--- a/src/app/src/test/resources/spec/Versions.schema.json
+++ b/src/app/src/test/resources/spec/Versions.schema.json
@@ -1,5 +1,7 @@
 {
-	"id": "Versions",
-    "type": "array",
-	"items": { "type": "string" }
+  "id": "Versions",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
 }

--- a/src/app/src/test/resources/spec/Versions.schema.json
+++ b/src/app/src/test/resources/spec/Versions.schema.json
@@ -1,5 +1,5 @@
 {
 	"id": "Versions",
-	"type": "array",
+    "type": "array",
 	"items": { "type": "string" }
 }

--- a/src/app/src/test/resources/spec/Versions.schema.json
+++ b/src/app/src/test/resources/spec/Versions.schema.json
@@ -1,0 +1,5 @@
+{
+	"id": "Versions",
+	"type": "array",
+	"items": { "type": "string" }
+}

--- a/src/app/src/test/resources/spec/spec.md
+++ b/src/app/src/test/resources/spec/spec.md
@@ -21,22 +21,19 @@ Some files are directly copied over (with only whitespace changes) from `montagu
 
 ## GET /reports/
 
-Return a list of all report names.
+Return a list of all reports with minimal metadata - the id, human readable name, and latest version of each.
 
 Required permissions: `reports.read`.
 
-Schema: [`Report.schema.json`](Reports.schema.json)
+Schema: [`Reports.schema.json`](Reports.schema.json)
 
 ### Example
 
 ```json
 
   [
-    "minimal",
-    "other",
-    "use_resource",
-    "multi-artefact",
-    "multifile-artefact"
+    {"id": "minimal", "name": "Minimal example", "latest_version": "20161010-121958-d5f0ea63"},
+    {"id": "use_resource", "name": "Use resources example", "latest_version": "20171011-121958-effh734"}       
   ]
 
 ```
@@ -47,7 +44,7 @@ Returns a list of version names for the named report.
 
 Required permissions: `reports.read`.
 
-Schema: [`Report.schema.json`](Report.schema.json)
+Schema: [`Versions.schema.json`](Version.schema.json)
 
 ### Example
 

--- a/src/app/src/test/resources/spec/spec.md
+++ b/src/app/src/test/resources/spec/spec.md
@@ -32,8 +32,8 @@ Schema: [`Reports.schema.json`](Reports.schema.json)
 ```json
 
   [
-    {"id": "minimal", "name": "Minimal example", "latest_version": "20161010-121958-d5f0ea63"},
-    {"id": "use_resource", "name": "Use resources example", "latest_version": "20171011-121958-effh734"}       
+    {"name": "minimal", "display_name": "Minimal example", "latest_version": "20161010-121958-d5f0ea63"},
+    {"name": "use_resource", "display_name": "Use resources example", "latest_version": "20171011-121958-effh734"}       
   ]
 
 ```


### PR DESCRIPTION
Now returns name, display name (nullable) and latest version id, rather than just an array of names.

Associated webmodels PR: https://github.com/vimc/montagu-webmodels/pull/22