### PR TITLE
get most recent published version

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/Orderly.kt
@@ -26,6 +26,7 @@ class Orderly(isReviewer: Boolean = false) : OrderlyClient
             val allReports = it.dsl.select(ORDERLY.NAME,
                     ORDERLY.DATE.max().`as`("maxDate"))
                     .from(ORDERLY)
+                    .where(shouldInclude)
                     .groupBy(ORDERLY.NAME)
 
             return it.dsl.with(tempTable).`as`(allReports)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/database_tests/OrderlyTests.kt
@@ -16,13 +16,14 @@ class OrderlyTests : DatabaseTests()
     }
 
     @Test
-    fun `can get all published report names`()
+    fun `can get all published reports`()
     {
 
         insertReport("test", "va")
         insertReport("test", "vz")
         insertReport("test2", "vc")
         insertReport("test2", "vb")
+        insertReport("test2", "vd", published = false)
         insertReport("test3", "test3version", published = false)
 
         val sut = createSut()


### PR DESCRIPTION
This fixes the following bug, introduced in https://github.com/vimc/montagu-reporting-api/commit/6549b403d73e4f400b88371abacf13b8aabff68d: If the most recent version of a report isn't published, that report wouldn't get returned with /reports/, even if other versions were published.