### PR TITLE
I1530 - lock down report reading endpoints

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/ReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/ReportRouteConfig.kt
@@ -15,11 +15,13 @@ object ReportRouteConfig : RouteConfig
             Endpoint("/reports/", controller, "getAllNames")
                     .json()
                     .transform()
+                    // more specific permission checking in the controller action
                     .secure(),
 
             Endpoint("/reports/:name/", controller, "getVersionsByName")
                     .json()
                     .transform()
+                    // more specific permission checking in the controller action
                     .secure(),
 
             Endpoint("/reports/:name/run/", controller, "run",

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/ReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/ReportRouteConfig.kt
@@ -8,6 +8,7 @@ import spark.route.HttpMethod
 object ReportRouteConfig : RouteConfig
 {
     private val runReports = setOf("*/reports.run")
+    private val readReports = setOf("report:<name>/reports.read")
     private val controller = ReportController::class
 
     override val endpoints: List<EndpointDefinition> = listOf(
@@ -21,8 +22,7 @@ object ReportRouteConfig : RouteConfig
             Endpoint("/reports/:name/", controller, "getVersionsByName")
                     .json()
                     .transform()
-                    // more specific permission checking in the controller action
-                    .secure(),
+                    .secure(readReports),
 
             Endpoint("/reports/:name/run/", controller, "run",
                     method = HttpMethod.post)

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/ReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/ReportRouteConfig.kt
@@ -7,7 +7,6 @@ import spark.route.HttpMethod
 
 object ReportRouteConfig : RouteConfig
 {
-    private val readReports = setOf("*/reports.read")
     private val runReports = setOf("*/reports.run")
     private val controller = ReportController::class
 
@@ -16,12 +15,12 @@ object ReportRouteConfig : RouteConfig
             Endpoint("/reports/", controller, "getAllNames")
                     .json()
                     .transform()
-                    .secure(readReports),
+                    .secure(),
 
             Endpoint("/reports/:name/", controller, "getVersionsByName")
                     .json()
                     .transform()
-                    .secure(readReports),
+                    .secure(),
 
             Endpoint("/reports/:name/run/", controller, "run",
                     method = HttpMethod.post)

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
@@ -21,12 +21,12 @@ object VersionRouteConfig : RouteConfig
             Endpoint("/reports/:name/versions/:version/", reportController, "getByNameAndVersion")
                     .json()
                     .transform()
-                    .secure(readReports),
+                    .secure(),
 
             Endpoint("/reports/:name/versions/:version/all/", reportController, "getZippedByNameAndVersion",
                     ContentTypes.zip)
                     .allowParameterAuthentication()
-                    .secure(readReports),
+                    .secure(),
 
             Endpoint("/reports/:name/versions/:version/publish/", reportController, "publish",
                     method = HttpMethod.post)

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
@@ -10,7 +10,7 @@ import spark.route.HttpMethod
 
 object VersionRouteConfig : RouteConfig
 {
-    private val readReports = setOf("*/reports.read")
+    private val readReports = setOf("report:<name>/reports.read")
     private val reviewReports = setOf("*/reports.review")
     private val artefactController = ArtefactController::class
     private val reportController = ReportController::class
@@ -21,14 +21,12 @@ object VersionRouteConfig : RouteConfig
             Endpoint("/reports/:name/versions/:version/", reportController, "getByNameAndVersion")
                     .json()
                     .transform()
-                    // more specific permission checking in the controller action
-                    .secure(),
+                    .secure(readReports),
 
             Endpoint("/reports/:name/versions/:version/all/", reportController, "getZippedByNameAndVersion",
                     ContentTypes.zip)
                     .allowParameterAuthentication()
-                    // more specific permission checking in the controller action
-                    .secure(),
+                    .secure(readReports),
 
             Endpoint("/reports/:name/versions/:version/publish/", reportController, "publish",
                     method = HttpMethod.post)

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
@@ -10,7 +10,7 @@ import spark.route.HttpMethod
 
 object VersionRouteConfig : RouteConfig
 {
-    private val readReports = setOf("report:<name>/reports.read")
+    private val readReports = setOf("*/reports.read")
     private val reviewReports = setOf("*/reports.review")
     private val artefactController = ArtefactController::class
     private val reportController = ReportController::class

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
@@ -10,7 +10,7 @@ import spark.route.HttpMethod
 
 object VersionRouteConfig : RouteConfig
 {
-    private val readReports = setOf("*/reports.read")
+    private val readReports = setOf("report:<name>/reports.read")
     private val reviewReports = setOf("*/reports.review")
     private val artefactController = ArtefactController::class
     private val reportController = ReportController::class

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/VersionRouteConfig.kt
@@ -21,11 +21,13 @@ object VersionRouteConfig : RouteConfig
             Endpoint("/reports/:name/versions/:version/", reportController, "getByNameAndVersion")
                     .json()
                     .transform()
+                    // more specific permission checking in the controller action
                     .secure(),
 
             Endpoint("/reports/:name/versions/:version/all/", reportController, "getZippedByNameAndVersion",
                     ContentTypes.zip)
                     .allowParameterAuthentication()
+                    // more specific permission checking in the controller action
                     .secure(),
 
             Endpoint("/reports/:name/versions/:version/publish/", reportController, "publish",

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ReportController.kt
@@ -54,7 +54,7 @@ class ReportController(context: ActionContext,
     {
         if (!reportReadingScopes.any())
         {
-            throw MissingRequiredPermissionError(setOf(ReifiedPermission("reports.read", Scope.Global())))
+            throw MissingRequiredPermissionError(PermissionSet("*/reports.read"))
         }
 
         val reports = orderly.getAllReports()

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
@@ -19,49 +19,36 @@ class RequestHelper
     private val baseUrl: String = "http://localhost:${AppConfig()["app.port"]}/v1"
     private val parser = JsonParser()
 
-    val fakeUser = InternalUser("tettusername", "user", "*/can-login,*/reports.read")
+    val fakeSingleReportReader = InternalUser("tettusername", "user", "*/can-login,report:report1/reports.read")
+    val fakeGlobalReportReader = InternalUser("tettusername", "user", "*/can-login,*/reports.read")
     val fakeReviewer = InternalUser("testreviewer", "reports-reviewer", "*/can-login,*/reports.read,*/reports.review,*/reports.run")
 
-    fun get(url: String, contentType: String = ContentTypes.json, reviewer: Boolean = false): Response
+    fun get(url: String, contentType: String = ContentTypes.json, user: InternalUser = fakeGlobalReportReader): Response
     {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
         )
 
-        val token = if (!reviewer)
-        {
-            APITests.tokenHelper
-                    .generateToken(fakeUser)
-        }
-        else
-        {
-            APITests.tokenHelper
-                    .generateToken(fakeReviewer)
-        }
+        val token = APITests.tokenHelper
+                .generateToken(user)
+
 
         headers += mapOf("Authorization" to "Bearer $token")
 
         return get(baseUrl + url, headers)
     }
 
-    fun post(url: String, body: Map<String, String>, contentType: String = ContentTypes.json, reviewer: Boolean = false): Response
+    fun post(url: String, body: Map<String, String>, contentType: String = ContentTypes.json,
+             user: InternalUser = fakeGlobalReportReader): Response
     {
         var headers = mapOf(
                 "Accept" to contentType,
                 "Accept-Encoding" to "gzip"
         )
 
-        val token = if (!reviewer)
-        {
-            APITests.tokenHelper
-                    .generateToken(fakeUser)
-        }
-        else
-        {
-            APITests.tokenHelper
-                    .generateToken(fakeReviewer)
-        }
+        val token = APITests.tokenHelper
+                .generateToken(user)
 
         headers += mapOf("Authorization" to "Bearer $token")
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
@@ -19,8 +19,8 @@ class RequestHelper
     private val baseUrl: String = "http://localhost:${AppConfig()["app.port"]}/v1"
     private val parser = JsonParser()
 
-    val fakeUser = InternalUser("tettusername", "user", "*/can-login", "*/reports.read")
-    val fakeReviewer = InternalUser("testreviewer", "*/can-login", "reports-reviewer", "*/reports.read,*/reports.review,*/reports.run")
+    val fakeUser = InternalUser("tettusername", "user", "*/reports.read,*/can-login")
+    val fakeReviewer = InternalUser("testreviewer", "reports-reviewer", "*/can-login,/reports.read,*/reports.review,*/reports.run")
 
     fun get(url: String, contentType: String = ContentTypes.json, reviewer: Boolean = false): Response
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
@@ -20,7 +20,7 @@ class RequestHelper
     private val parser = JsonParser()
 
     val fakeUser = InternalUser("tettusername", "user", "*/reports.read,*/can-login")
-    val fakeReviewer = InternalUser("testreviewer", "reports-reviewer", "*/can-login,/reports.read,*/reports.review,*/reports.run")
+    val fakeReviewer = InternalUser("testreviewer", "reports-reviewer", "*/can-login,*/reports.read,*/reports.review,*/reports.run")
 
     fun get(url: String, contentType: String = ContentTypes.json, reviewer: Boolean = false): Response
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
@@ -92,7 +92,7 @@ class ArtefactTests : IntegrationTest()
         insertReport("testname", "testversion")
         val url = "/reports/testname/versions/testversion/artefacts/6943yhks/"
         val token = WebTokenHelper.oneTimeTokenHelper.issuer
-                .generateOnetimeActionToken(requestHelper.fakeUser, url)
+                .generateOnetimeActionToken(requestHelper.fakeGlobalReportReader, url)
         val response = requestHelper
                 .getNoAuth("$url?access_token=$token", ContentTypes.binarydata)
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/GitTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/GitTests.kt
@@ -8,7 +8,7 @@ class GitTests : IntegrationTest()
     @Test
     fun `gets git status`()
     {
-        val response = requestHelper.get("/reports/git/status/", reviewer = true)
+        val response = requestHelper.get("/reports/git/status/", user = requestHelper.fakeReviewer)
 
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)
@@ -18,7 +18,7 @@ class GitTests : IntegrationTest()
     @Test
     fun `pulls`()
     {
-        val response = requestHelper.post("/reports/git/pull/", mapOf(), reviewer = true)
+        val response = requestHelper.post("/reports/git/pull/", mapOf(), user = requestHelper.fakeReviewer)
 
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)
@@ -28,7 +28,7 @@ class GitTests : IntegrationTest()
     @Test
     fun `fetches`()
     {
-        val response = requestHelper.post("/reports/git/fetch/", mapOf(), reviewer = true)
+        val response = requestHelper.post("/reports/git/fetch/", mapOf(),  user = requestHelper.fakeReviewer)
 
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/IntegrationTest.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/IntegrationTest.kt
@@ -80,6 +80,16 @@ abstract class IntegrationTest : MontaguTests()
         Assertions.assertThat(response.headers["Content-Encoding"]).isEqualTo("gzip")
     }
 
+    protected fun assertUnauthorized(response: Response, reportName: String)
+    {
+        Assertions.assertThat(response.statusCode)
+                .isEqualTo(403)
+
+        JSONValidator.validateError(response.text, "forbidden",
+                "You do not have sufficient permissions to access this resource. Missing these permissions: report:${reportName}/reports.read")
+
+    }
+
     protected fun assertJsonContentType(response: Response)
     {
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json; charset=utf-8")

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
@@ -202,6 +202,20 @@ class ReportTests : IntegrationTest()
     }
 
     @Test
+    fun `gets zip file with scoped permissions`()
+    {
+        insertReport("testname", "testversion")
+
+        val response = requestHelper.get("/reports/testname/versions/testversion/all/", contentType = ContentTypes.zip,
+                user = InternalUser("testusername", "user", "*/can-login,report:testname/reports.read"))
+
+        assertSuccessful(response)
+        assertThat(response.headers["content-type"]).isEqualTo("application/zip")
+        assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=testname/testversion.zip")
+    }
+
+
+    @Test
     fun `gets zip file with bearer token`()
     {
         insertReport("testname", "testversion")
@@ -215,7 +229,7 @@ class ReportTests : IntegrationTest()
     }
 
     @Test
-    fun `returns 401 if access token is missing`()
+    fun `get zip returns 401 if access token is missing`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.getNoAuth("/reports/testname/versions/testversion/all", contentType = ContentTypes.zip)
@@ -225,7 +239,7 @@ class ReportTests : IntegrationTest()
     }
 
     @Test
-    fun `returns 403 if wrong report reading permissions`()
+    fun `get zip returns 403 if wrong report reading permissions`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.get("/reports/testname/versions/testversion/all",

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/SecurityTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/SecurityTests.kt
@@ -43,7 +43,7 @@ class SecurityTests : IntegrationTest()
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
         Assertions.assertThat(response.statusCode).isEqualTo(403)
         JSONValidator.validateError(response.text, "forbidden",
-                "You do not have sufficient permissions to access this resource. Missing these permissions: */reports.read")
+                "You do not have sufficient permissions to access this resource. Missing these permissions: */can-login")
 
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ReportControllerTests.kt
@@ -134,6 +134,7 @@ class ReportControllerTests : ControllerTest()
         }
 
         val mockContext = mock<ActionContext> {
+            on { this.permissions } doReturn PermissionSet()
             on { it.params(":name") } doReturn reportName
         }
 
@@ -157,6 +158,7 @@ class ReportControllerTests : ControllerTest()
         }
 
         val actionContext = mock<ActionContext> {
+            on { this.permissions } doReturn PermissionSet()
             on { this.params(":version") } doReturn reportVersion
             on { this.params(":name") } doReturn reportName
         }
@@ -171,7 +173,6 @@ class ReportControllerTests : ControllerTest()
     @Test
     fun `getZippedByNameAndVersion returns zip file`()
     {
-
         val reportName = "reportName"
         val reportVersion = "reportVersion"
 
@@ -179,6 +180,7 @@ class ReportControllerTests : ControllerTest()
             on { this.params(":version") } doReturn reportVersion
             on { this.params(":name") } doReturn reportName
             on { this.getSparkResponse() } doReturn mockSparkResponse
+            on { this.permissions } doReturn PermissionSet()
         }
 
         val mockZipClient = mock<ZipClient>()


### PR DESCRIPTION
Should allow through users who either have global report reading permissions, or scoped to the given report name.