### PR TITLE
I1530 more tests for scoped report reading permissions

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/HomeRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/app_start/Routing/HomeRouteConfig.kt
@@ -11,7 +11,7 @@ object HomeRouteConfig : RouteConfig
 
             Endpoint("/onetime_token/", OnetimeTokenController::class, "get")
                     .json()
-                    .secure(setOf("*/reports.read"))
+                    .secure()
                     .transform(),
 
             Endpoint("/", HomeController::class, "index")

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
@@ -19,7 +19,6 @@ class RequestHelper
     private val baseUrl: String = "http://localhost:${AppConfig()["app.port"]}/v1"
     private val parser = JsonParser()
 
-    val fakeSingleReportReader = InternalUser("tettusername", "user", "*/can-login,report:report1/reports.read")
     val fakeGlobalReportReader = InternalUser("tettusername", "user", "*/can-login,*/reports.read")
     val fakeReviewer = InternalUser("testreviewer", "reports-reviewer", "*/can-login,*/reports.read,*/reports.review,*/reports.run")
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/helpers/RequestHelper.kt
@@ -55,9 +55,9 @@ class RequestHelper
         return khttp.post(baseUrl + url, headers, json = body)
     }
 
-    fun generateOnetimeToken(url: String): String
+    fun generateOnetimeToken(url: String, user: InternalUser = fakeGlobalReportReader): String
     {
-        val response = get("/onetime_token/?url=/v1$url")
+        val response = get("/onetime_token/?url=/v1$url", user = user)
         val json = parser.parse(response.text)
         if (json["status"].asString != "success")
         {

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
@@ -11,10 +11,12 @@ import org.vaccineimpact.reporting_api.tests.insertReport
 class ArtefactTests : IntegrationTest()
 {
     @Test
-    fun `gets dict of artefact names to hashes with global permissions`()
+    fun `gets dict of artefact names to hashes with report scoped permission`()
     {
         insertReport("testname", "testversion")
-        val response = requestHelper.get("/reports/testname/versions/testversion/artefacts/")
+        val response = requestHelper.get("/reports/testname/versions/testversion/artefacts/",
+                user = fakeReportReader("testname"))
+
 
         assertJsonContentType(response)
         assertSuccessful(response)
@@ -22,21 +24,11 @@ class ArtefactTests : IntegrationTest()
     }
 
     @Test
-    fun `gets dict of artefact names to hashes with report scoped permission`()
-    {
-        insertReport("testname", "testversion")
-        val response = requestHelper.get("/reports/testname/versions/testversion/artefacts/",
-                user = fakeReportReader("testname"))
-
-        assertJsonContentType(response)
-    }
-
-    @Test
     fun `cant get artefacts dict if report not within report reading scope`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.get("/reports/testname/versions/testversion/artefacts/",
-                user = requestHelper.fakeSingleReportReader)
+                user = fakeReportReader("badreportname"))
 
         assertUnauthorized(response, "testname")
     }
@@ -87,7 +79,7 @@ class ArtefactTests : IntegrationTest()
 
         val url = "/reports/other/versions/$publishedVersion/artefacts/graph.png/"
         val response = requestHelper.get(url, ContentTypes.binarydata,
-                user = requestHelper.fakeSingleReportReader)
+                user = fakeReportReader("badreportname"))
 
         assertUnauthorized(response, "other")
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
@@ -4,13 +4,14 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.vaccineimpact.reporting_api.ContentTypes
 import org.vaccineimpact.reporting_api.db.Orderly
+import org.vaccineimpact.reporting_api.security.InternalUser
 import org.vaccineimpact.reporting_api.security.WebTokenHelper
 import org.vaccineimpact.reporting_api.tests.insertReport
 
 class ArtefactTests : IntegrationTest()
 {
     @Test
-    fun `gets dict of artefact names to hashes`()
+    fun `gets dict of artefact names to hashes with global permissions`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.get("/reports/testname/versions/testversion/artefacts/")
@@ -18,6 +19,26 @@ class ArtefactTests : IntegrationTest()
         assertJsonContentType(response)
         assertSuccessful(response)
         JSONValidator.validateAgainstSchema(response.text, "Dictionary")
+    }
+
+    @Test
+    fun `gets dict of artefact names to hashes with report scoped permission`()
+    {
+        insertReport("testname", "testversion")
+        val response = requestHelper.get("/reports/testname/versions/testversion/artefacts/",
+                user = fakeReportReader("testname"))
+
+        assertJsonContentType(response)
+    }
+
+    @Test
+    fun `cant get artefacts dict if report not within report reading scope`()
+    {
+        insertReport("testname", "testversion")
+        val response = requestHelper.get("/reports/testname/versions/testversion/artefacts/",
+                user = requestHelper.fakeSingleReportReader)
+
+        assertUnauthorized(response, "testname")
     }
 
     @Test
@@ -48,6 +69,30 @@ class ArtefactTests : IntegrationTest()
     }
 
     @Test
+    fun `can get artefact file with scoped report reading permission`()
+    {
+        val publishedVersion = Orderly().getReportsByName("other")[0]
+
+        val url = "/reports/other/versions/$publishedVersion/artefacts/graph.png/"
+        val response = requestHelper.get(url, ContentTypes.binarydata,
+                user = fakeReportReader("other"))
+
+        assertSuccessful(response)
+    }
+
+    @Test
+    fun `can't get artefact file if report not within report reading scope`()
+    {
+        val publishedVersion = Orderly().getReportsByName("other")[0]
+
+        val url = "/reports/other/versions/$publishedVersion/artefacts/graph.png/"
+        val response = requestHelper.get(url, ContentTypes.binarydata,
+                user = requestHelper.fakeSingleReportReader)
+
+        assertUnauthorized(response, "other")
+    }
+
+    @Test
     fun `gets 404 if artefact doesnt exist in db`()
     {
         insertReport("testname", "testversion")
@@ -60,47 +105,6 @@ class ArtefactTests : IntegrationTest()
         Assertions.assertThat(response.statusCode).isEqualTo(404)
         JSONValidator.validateError(response.text, "unknown-artefact", "Unknown artefact : '$fakeartefact'")
     }
-
-    @Test
-    fun `gets 401 if missing access token and no auth`()
-    {
-        insertReport("testname", "testversion")
-        val fakeartefact = "hf647rhj"
-
-        val url = "/reports/testname/versions/testversion/artefacts/$fakeartefact"
-        val response = requestHelper.getNoAuth("$url/", ContentTypes.binarydata)
-
-        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
-        Assertions.assertThat(response.statusCode).isEqualTo(401)
-        JSONValidator.validateMultipleAuthErrors(response.text)
-    }
-
-    @Test
-    fun `gets 401 if invalid access token`()
-    {
-        insertReport("testname", "testversion")
-        val response = requestHelper.getNoAuth("/reports/testname/versions/testversion/artefacts/fakeartefact/?access_token=42678iwek", ContentTypes.binarydata)
-
-        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
-        Assertions.assertThat(response.statusCode).isEqualTo(401)
-        JSONValidator.validateMultipleAuthErrors(response.text)
-    }
-
-    @Test
-    fun `gets 401 if access token not in db`()
-    {
-        insertReport("testname", "testversion")
-        val url = "/reports/testname/versions/testversion/artefacts/6943yhks/"
-        val token = WebTokenHelper.oneTimeTokenHelper.issuer
-                .generateOnetimeActionToken(requestHelper.fakeGlobalReportReader, url)
-        val response = requestHelper
-                .getNoAuth("$url?access_token=$token", ContentTypes.binarydata)
-
-        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
-        Assertions.assertThat(response.statusCode).isEqualTo(401)
-        JSONValidator.validateMultipleAuthErrors(response.text)
-    }
-
 
     @Test
     fun `gets 404 if artefact file doesnt exist`()

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/DataTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/DataTests.kt
@@ -24,7 +24,7 @@ class DataTests : IntegrationTest()
     }
 
     @Test
-    fun `can't gets dict of data names if report not within report reading scope`()
+    fun `can't get dict of data names if report not within report reading scope`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.get("/reports/testname/versions/testversion/data/",
@@ -52,7 +52,7 @@ class DataTests : IntegrationTest()
     }
 
     @Test
-    fun `can't gets csv data file if report not in scoped permissions`()
+    fun `can't get csv data file if report not in scoped permissions`()
     {
 
         var demoCSV = File("${AppConfig()["orderly.root"]}/data/csv/").list()[0]

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/DataTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/DataTests.kt
@@ -11,26 +11,16 @@ class DataTests : IntegrationTest()
 {
 
     @Test
-    fun `gets dict of data names to hashes`()
-    {
-
-        insertReport("testname", "testversion")
-        val response = requestHelper.get("/reports/testname/versions/testversion/data/")
-
-        assertJsonContentType(response)
-        assertSuccessful(response)
-        JSONValidator.validateAgainstSchema(response.text, "Dictionary")
-
-    }
-
-    @Test
     fun `gets dict of data names to hashes with scoped report reading permission`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.get("/reports/testname/versions/testversion/data/",
                 user = fakeReportReader("testname"))
 
+        assertJsonContentType(response)
         assertSuccessful(response)
+        JSONValidator.validateAgainstSchema(response.text, "Dictionary")
+
     }
 
     @Test
@@ -44,29 +34,8 @@ class DataTests : IntegrationTest()
     }
 
     @Test
-    fun `gets csv data file`()
-    {
-
-        var demoCSV = File("${AppConfig()["orderly.root"]}/data/csv/").list()[0]
-
-        // remove file extension
-        demoCSV = demoCSV.substring(0, demoCSV.length - 4)
-
-        insertReport("testname", "testversion", hashData = "{ \"testdata\" : \"$demoCSV\"}")
-
-        val url = "/reports/testname/versions/testversion/data/testdata/"
-        val token = requestHelper.generateOnetimeToken(url)
-        val response = requestHelper.getNoAuth("$url?access_token=$token", ContentTypes.binarydata)
-
-        assertSuccessful(response)
-        Assertions.assertThat(response.headers["content-type"]).isEqualTo("text/csv")
-        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=$demoCSV.csv")
-    }
-
-    @Test
     fun `gets csv data file with scoped permission`()
     {
-
         var demoCSV = File("${AppConfig()["orderly.root"]}/data/csv/").list()[0]
 
         // remove file extension
@@ -78,6 +47,8 @@ class DataTests : IntegrationTest()
         val response = requestHelper.get(url, ContentTypes.binarydata, user = fakeReportReader("testname"))
 
         assertSuccessful(response)
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("text/csv")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=$demoCSV.csv")
     }
 
     @Test
@@ -134,24 +105,21 @@ class DataTests : IntegrationTest()
     @Test
     fun `gets rds data file`()
     {
-
         var demoRDS = File("${AppConfig()["orderly.root"]}/data/rds/").list()[0]
 
         // remove file extension
         demoRDS = demoRDS.substring(0, demoRDS.length - 4)
 
-        val url = "/reports/testname/versions/testversion/data/testdata?type=rds"
-        val token = requestHelper.generateOnetimeToken(url)
-
         insertReport("testname", "testversion", hashData = "{ \"testdata\" : \"$demoRDS\"}")
-        val response = requestHelper.getNoAuth("$url&access_token=$token",
-                ContentTypes.binarydata)
+
+        val url = "/reports/testname/versions/testversion/data/testdata/"
+        val token = requestHelper.generateOnetimeToken(url)
+        val response = requestHelper.getNoAuth("$url?type=rds&access_token=$token", ContentTypes.binarydata)
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/octet-stream")
         Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=$demoRDS.rds")
     }
-
 
     @Test
     fun `gets csv data file by hash`()

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/IntegrationTest.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/IntegrationTest.kt
@@ -8,6 +8,7 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.vaccineimpact.reporting_api.app_start.main
 import org.vaccineimpact.reporting_api.db.AppConfig
+import org.vaccineimpact.reporting_api.security.InternalUser
 import org.vaccineimpact.reporting_api.test_helpers.MontaguTests
 import org.vaccineimpact.reporting_api.tests.integration_tests.APITests
 import org.vaccineimpact.reporting_api.tests.integration_tests.helpers.RequestHelper
@@ -68,6 +69,7 @@ abstract class IntegrationTest : MontaguTests()
     {
         Assertions.assertThat(response.statusCode)
                 .isEqualTo(200)
+
         Assertions.assertThat(response.headers["Content-Encoding"]).isEqualTo("gzip")
     }
 
@@ -93,6 +95,11 @@ abstract class IntegrationTest : MontaguTests()
     protected fun assertJsonContentType(response: Response)
     {
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json; charset=utf-8")
+    }
+
+    protected fun fakeReportReader(reportName: String): InternalUser
+    {
+        return InternalUser("tettusername", "user", "*/can-login,report:$reportName/reports.read")
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ReportTests.kt
@@ -116,7 +116,7 @@ class ReportTests : IntegrationTest()
     fun `get report versions throws 403 if user not authorized to read report`()
     {
         insertReport("testname", "testversion")
-        val response = requestHelper.get("/reports/testname", user = requestHelper.fakeSingleReportReader)
+        val response = requestHelper.get("/reports/testname", user = fakeReportReader("badreportname"))
 
         assertUnauthorized(response, "testname")
     }
@@ -155,11 +155,11 @@ class ReportTests : IntegrationTest()
     }
 
     @Test
-    fun `get by name and version returns 403 if user is unauthorized`()
+    fun `get by name and version returns 403 if report not in scoped permissions`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.get("/reports/testname/versions/testversion",
-                user = requestHelper.fakeSingleReportReader)
+                user = fakeReportReader("badreportname"))
         assertUnauthorized(response, "testname")
     }
 
@@ -239,11 +239,11 @@ class ReportTests : IntegrationTest()
     }
 
     @Test
-    fun `get zip returns 403 if wrong report reading permissions`()
+    fun `get zip returns 403 if report not in scoped report reading permissions`()
     {
         insertReport("testname", "testversion")
         val response = requestHelper.get("/reports/testname/versions/testversion/all",
-                contentType = ContentTypes.zip, user = requestHelper.fakeSingleReportReader)
+                contentType = ContentTypes.zip, user = fakeReportReader("badreportnamer"))
 
         Assertions.assertThat(response.statusCode).isEqualTo(403)
         JSONValidator.validateError(response.text, "forbidden",

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/SecurityTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/SecurityTests.kt
@@ -3,11 +3,16 @@ package org.vaccineimpact.reporting_api.tests.integration_tests.tests
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.vaccineimpact.reporting_api.ContentTypes
+import org.vaccineimpact.reporting_api.security.InternalUser
+import org.vaccineimpact.reporting_api.security.WebTokenHelper
 import org.vaccineimpact.reporting_api.tests.insertReport
+import org.vaccineimpact.reporting_api.tests.integration_tests.APITests
 import org.vaccineimpact.reporting_api.tests.integration_tests.helpers.RequestHelper
 
 class SecurityTests : IntegrationTest()
 {
+
+    /**  Bearer token tests */
 
     @Test
     fun `returns 401 if token missing`()
@@ -47,32 +52,85 @@ class SecurityTests : IntegrationTest()
 
     }
 
-    // TODO: We can't test this until there is an endpoint that requires more permissions than the user has.
-    // This should be fixed as part of the work on VIMC-410
-//    @Test
-//    fun `returns 403 if missing permissions with access token`()
-//    {
-//        val response = RequestHelper().getWrongPermissionsWithAccessToken("/reports/testname/versions/testversion/artefacts/someartefact/", ContentTypes.binarydata)
-//
-//        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
-//        Assertions.assertThat(response.statusCode).isEqualTo(403)
-//        JSONValidator.validateError(response.text, "forbidden",
-//                "You do not have sufficient permissions to access this resource. Missing these permissions: */reports.read")
-//    }
+    /**  Access token tests */
+
+    @Test
+    fun `returns 403 if missing permissions with access token`()
+    {
+        val url = "/reports/testname/versions/testversion/artefacts/someartefact/"
+        val token = requestHelper.generateOnetimeToken(url, fakeReportReader("wrongreport"))
+
+        val response = requestHelper
+                .getNoAuth("/reports/testname/versions/testversion/artefacts/someartefact/?access_token=$token",
+                        ContentTypes.binarydata)
+
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
+        Assertions.assertThat(response.statusCode).isEqualTo(403)
+        JSONValidator.validateError(response.text, "forbidden",
+                "You do not have sufficient permissions to access this resource." +
+                        " Missing these permissions: report:testname/reports.read")
+    }
 
     @Test
     fun `returns 403 if access token url is wrong`()
     {
         insertReport("testname", "testversion")
 
-        val token = requestHelper.generateOnetimeToken("/reports/testname/versions/testversion/artefacts/someartefact/")
-        val response = RequestHelper().getNoAuth("/reports/testname/versions/testversion/artefacts/someotherartefact/?access_token=$token", ContentTypes.binarydata)
+        val token = requestHelper
+                .generateOnetimeToken("/reports/testname/versions/testversion/artefacts/someartefact/")
+        val response = requestHelper
+                .getNoAuth("/reports/testname/versions/testversion/artefacts/someotherartefact/?access_token=$token",
+                        ContentTypes.binarydata)
 
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
         Assertions.assertThat(response.statusCode).isEqualTo(403)
         JSONValidator.validateError(response.text, "forbidden",
-                "This token is issued for /v1/reports/testname/versions/testversion/artefacts/someartefact/ but the current request is for /v1/reports/testname/versions/testversion/artefacts/someotherartefact/")
+                "This token is issued for /v1/reports/testname/versions/testversion/artefacts/someartefact/ but the " +
+                        "current request is for /v1/reports/testname/versions/testversion/artefacts/someotherartefact/")
 
+    }
+
+    @Test
+    fun `return 401 if invalid access token`()
+    {
+        insertReport("testname", "testversion")
+        val response = requestHelper
+                .getNoAuth("/reports/testname/versions/testversion/artefacts/fakeartefact/?access_token=42678iwek",
+                        ContentTypes.binarydata)
+
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
+        Assertions.assertThat(response.statusCode).isEqualTo(401)
+        JSONValidator.validateMultipleAuthErrors(response.text)
+
+    }
+
+    @Test
+    fun `returns 401 if access token not in db`()
+    {
+        insertReport("testname", "testversion")
+        val url = "/reports/testname/versions/testversion/artefacts/6943yhks/"
+        val token = WebTokenHelper.oneTimeTokenHelper.issuer
+                .generateOnetimeActionToken(requestHelper.fakeGlobalReportReader, url)
+        val response = requestHelper
+                .getNoAuth("$url?access_token=$token", ContentTypes.binarydata)
+
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
+        Assertions.assertThat(response.statusCode).isEqualTo(401)
+        JSONValidator.validateMultipleAuthErrors(response.text)
+    }
+
+    @Test
+    fun `returns 401 if missing access token and no auth`()
+    {
+        insertReport("testname", "testversion")
+        val fakeartefact = "hf647rhj"
+
+        val url = "/reports/testname/versions/testversion/artefacts/$fakeartefact"
+        val response = requestHelper.getNoAuth("$url/", ContentTypes.binarydata)
+
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/json")
+        Assertions.assertThat(response.statusCode).isEqualTo(401)
+        JSONValidator.validateMultipleAuthErrors(response.text)
     }
 
 


### PR DESCRIPTION
There are still 2 endpoints requiring global report reading permission - getting data files by id. This is because they aren't parameterized by report name, and given the current way in which data is stored in the db, it would be a real pain to work out which report they actually belong to! Once the orderly index refactor is in, this will be much easier.