### PR TITLE
I1991 - make url matching query string sensitive

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/security/MontaguAuthorizer.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/security/MontaguAuthorizer.kt
@@ -21,7 +21,17 @@ open class MontaguAuthorizer(requiredPermissions: Set<PermissionRequirement>)
     override fun isProfileAuthorized(context: WebContext, profile: CommonProfile): Boolean
     {
         val claimedUrl = profile.getAttribute("url")
-        val requestedUrl = context.path
+        var requestedUrl = context.path
+        val queryParameters = context.requestParameters
+                .filter { it.key != "access_token" }
+
+        if (queryParameters.any())
+        {
+            requestedUrl = requestedUrl + "?" + queryParameters
+                    .map { "${it.key}=${context.getRequestParameter(it.key)}" }
+                    .joinToString("&")
+
+        }
 
         if (claimedUrl == "*" || requestedUrl == claimedUrl)
         {

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/DataTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/DataTests.kt
@@ -112,9 +112,9 @@ class DataTests : IntegrationTest()
 
         insertReport("testname", "testversion", hashData = "{ \"testdata\" : \"$demoRDS\"}")
 
-        val url = "/reports/testname/versions/testversion/data/testdata/"
+        val url = "/reports/testname/versions/testversion/data/testdata/?type=rds"
         val token = requestHelper.generateOnetimeToken(url)
-        val response = requestHelper.getNoAuth("$url?type=rds&access_token=$token", ContentTypes.binarydata)
+        val response = requestHelper.getNoAuth("$url&access_token=$token", ContentTypes.binarydata)
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/octet-stream")

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
@@ -39,6 +39,22 @@ class OnetimeTokenTests : IntegrationTest()
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
         Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=other/$publishedVersion/graph.png")
 
+    }
+
+    @Test
+    fun `can use one time token to authenticate endpoint with query string`()
+    {
+        val publishedVersion = Orderly().getReportsByName("other")[0]
+        val url = "/reports/other/versions/$publishedVersion/artefacts/graph.png/?query=whatever"
+
+        val tokenReponse = requestHelper.get("/onetime_token/?url=" + URLEncoder.encode("/v1$url", "UTF-8"))
+        val token = JsonLoader.fromString(tokenReponse.text)["data"].textValue()
+
+        val response = requestHelper.getNoAuth("$url&access_token=$token", ContentTypes.binarydata)
+
+        assertSuccessful(response)
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=other/$publishedVersion/graph.png")
 
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/security/MontaguAuthorizerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/security/MontaguAuthorizerTests.kt
@@ -26,7 +26,91 @@ class MontaguAuthorizerTests : MontaguTests()
         val result = sut.isAuthorized(fakeContext, listOf(profile))
 
         assertThat(result).isFalse()
+    }
 
+    @Test
+    fun `is authorized if url claim matches request`()
+    {
+        val sut = MontaguAuthorizer(setOf())
+
+        val profile = CommonProfile()
+        profile.addAttribute("url", "/some/url/")
+
+        val fakeContext = mock<SparkWebContext>() {
+            on(it.path) doReturn "/some/url/"
+        }
+
+        val result = sut.isAuthorized(fakeContext, listOf(profile))
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `is authorized if url claim matches request and query params match`()
+    {
+        val sut = MontaguAuthorizer(setOf())
+
+        val profile = CommonProfile()
+        profile.addAttribute("url", "/some/url/?query=whatever")
+
+        val fakeContext = mock<SparkWebContext>() {
+            on(it.path) doReturn "/some/url/?query=whatever"
+        }
+
+        val result = sut.isAuthorized(fakeContext, listOf(profile))
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `is not authorized if request does not contain same query params as claim`()
+    {
+        val sut = MontaguAuthorizer(setOf())
+
+        val profile = CommonProfile()
+        profile.addAttribute("url", "/some/url/?query=whatever")
+
+        val fakeContext = mock<SparkWebContext>() {
+            on(it.path) doReturn "/some/url/"
+        }
+
+        val result = sut.isAuthorized(fakeContext, listOf(profile))
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `is not authorized if claim does not have same query params as request`()
+    {
+        val sut = MontaguAuthorizer(setOf())
+
+        val profile = CommonProfile()
+        profile.addAttribute("url", "/some/url/")
+
+        val fakeContext = mock<SparkWebContext>() {
+            on(it.path) doReturn "/some/url/?query=whatever"
+        }
+
+        val result = sut.isAuthorized(fakeContext, listOf(profile))
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `is sensitive to query parameter values`()
+    {
+        val sut = MontaguAuthorizer(setOf())
+
+        val profile = CommonProfile()
+        profile.addAttribute("url", "/some/url/?query=whatever")
+
+        val fakeContext = mock<SparkWebContext>() {
+            on(it.path) doReturn "/some/url/?query=somethingelse"
+        }
+
+        val result = sut.isAuthorized(fakeContext, listOf(profile))
+
+        assertThat(result).isFalse()
     }
 
     @Test


### PR DESCRIPTION
When requesting a onetime token, we were ignoring all query strings. Given that in all other respects they are parameter sensitive, it feels consistent to make them query string sensitive. This is one way to solve the bug in the webapps where an inline artefact and a download link for the same artefact can't exist on the same page.