### PR TITLE
i2120: Attempt to simplify orderly logic

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/TempTable.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/db/TempTable.kt
@@ -1,0 +1,16 @@
+package org.vaccineimpact.reporting_api.db
+
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Select
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.name
+
+open class TempTable(val tableName: String, val query: Select<*>)
+{
+    inline fun <reified T> field(fieldName: String): Field<T> = DSL.field(name(tableName, fieldName), T::class.java)
+}
+
+fun DSLContext.withTemporaryTable(table: TempTable) = this.with(table.tableName).`as`(table.query)
+
+fun Select<*>.asTemporaryTable(name: String) = TempTable(name, this)


### PR DESCRIPTION
An extension to https://github.com/vimc/montagu-reporting-api/pull/42

This PR does two things:

1. Removes one join/temporary table step, which I think was unnecessary
2. Adds a `TempTable` class to make the temp table stuff a bit more OO and easier to reason about. I've long found the temp table bits of our jOOQ code the hardest to comprehend. If you like this pattern, maybe we can use it elsewhere.