### PR TITLE
I2728-latest Allow resource and artefacts with spaces in names to be downloaded

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/Helpers.kt
@@ -4,6 +4,7 @@ import spark.Filter
 import spark.Request
 import spark.Response
 import javax.servlet.http.HttpServletResponse
+import java.net.URLDecoder
 
 // The idea is that as this file grows, I'll group helpers and split them off into files/classes with more
 // specific aims.
@@ -29,5 +30,5 @@ class DefaultHeadersFilter(val contentType: String) : Filter
 
 fun parseRouteParamToFilepath(routeParam: String): String
 {
-    return routeParam.replace(":", "/")
+    return  URLDecoder.decode(routeParam.replace(":", "/")) //route param may include URL encoding
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ArtefactController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ArtefactController.kt
@@ -50,7 +50,7 @@ class ArtefactController(context: ActionContext,
         context.addDefaultResponseHeaders(guessFileType(filename))
         if (!inline)
         {
-            context.addResponseHeader("Content-Disposition", "attachment; filename=$filename")
+            context.addResponseHeader("Content-Disposition", "attachment; filename=\"$filename\"")
         }
 
         files.writeFileToOutputStream(absoluteFilePath, response.outputStream)

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
@@ -1,7 +1,6 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
-import java.net.URLDecoder
 import org.vaccineimpact.api.models.Scope
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.reporting_api.*
@@ -31,7 +30,7 @@ class ResourceController(context: ActionContext,
     {
         val name = context.params(":name")
         val version = context.params(":version")
-        val resourcename = URLDecoder.decode(parseRouteParamToFilepath(context.params(":resource")))
+        val resourcename = parseRouteParamToFilepath(context.params(":resource"))
 
         orderly.getResourceHash(name, version, resourcename)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/reporting_api/controllers/ResourceController.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.reporting_api.controllers
 
 import com.google.gson.JsonObject
+import java.net.URLDecoder
 import org.vaccineimpact.api.models.Scope
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.reporting_api.*
@@ -30,7 +31,7 @@ class ResourceController(context: ActionContext,
     {
         val name = context.params(":name")
         val version = context.params(":version")
-        val resourcename = parseRouteParamToFilepath(context.params(":resource"))
+        val resourcename = URLDecoder.decode(parseRouteParamToFilepath(context.params(":resource")))
 
         orderly.getResourceHash(name, version, resourcename)
 
@@ -41,7 +42,7 @@ class ResourceController(context: ActionContext,
         if (!files.fileExists(absoluteFilePath))
             throw OrderlyFileNotFoundError(resourcename)
 
-        context.addResponseHeader("Content-Disposition", "attachment; filename=$filename")
+        context.addResponseHeader("Content-Disposition", "attachment; filename=\"$filename\"")
         context.addDefaultResponseHeaders(ContentTypes.binarydata)
 
         val response = context.getSparkResponse().raw()

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ArtefactTests.kt
@@ -3,11 +3,13 @@ package org.vaccineimpact.reporting_api.tests.integration_tests.tests
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.vaccineimpact.reporting_api.ContentTypes
+import org.vaccineimpact.reporting_api.db.AppConfig
 import org.vaccineimpact.reporting_api.db.Orderly
 import org.vaccineimpact.reporting_api.security.InternalUser
 import org.vaccineimpact.reporting_api.security.WebTokenHelper
 import org.vaccineimpact.reporting_api.tests.insertArtefact
 import org.vaccineimpact.reporting_api.tests.insertReport
+import java.io.File
 
 class ArtefactTests : IntegrationTest()
 {
@@ -45,7 +47,7 @@ class ArtefactTests : IntegrationTest()
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
-        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=other/$publishedVersion/graph.png")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"other/$publishedVersion/graph.png\"")
     }
 
     @Test
@@ -58,7 +60,7 @@ class ArtefactTests : IntegrationTest()
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
-        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=other/$publishedVersion/graph.png")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"other/$publishedVersion/graph.png\"")
     }
 
     @Test
@@ -71,7 +73,20 @@ class ArtefactTests : IntegrationTest()
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
-        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=other/$publishedVersion/graph.png")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"other/$publishedVersion/graph.png\"")
+    }
+
+    @Test
+    fun `gets artefact file with space in name`()
+    {
+        val version = File("${AppConfig()["orderly.root"]}/archive/spaces/").list()[0]
+
+        val url = "/reports/spaces/versions/$version/artefacts/a+graph+with+spaces.png/"
+        val response = requestHelper.get(url, ContentTypes.binarydata, user = requestHelper.fakeReviewer)
+
+        assertSuccessful(response)
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"spaces/$version/a graph with spaces.png\"")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/OnetimeTokenTests.kt
@@ -37,7 +37,7 @@ class OnetimeTokenTests : IntegrationTest()
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
-        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=other/$publishedVersion/graph.png")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"other/$publishedVersion/graph.png\"")
 
     }
 
@@ -54,7 +54,7 @@ class OnetimeTokenTests : IntegrationTest()
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("image/png")
-        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=other/$publishedVersion/graph.png")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"other/$publishedVersion/graph.png\"")
 
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ResourceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ResourceTests.kt
@@ -55,7 +55,6 @@ class ResourceTests : IntegrationTest()
         val resourceEncoded = "a+resource+with+spaces.csv"
         val url = "/reports/spaces/versions/$version/resources/$resourceEncoded/"
 
-
         val testresponse = requestHelper.get("/reports/spaces/versions/$version/", user = requestHelper.fakeReviewer)
 
         assertSuccessful(testresponse)

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ResourceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/integration_tests/tests/ResourceTests.kt
@@ -43,7 +43,29 @@ class ResourceTests : IntegrationTest()
 
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/octet-stream")
-        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=use_resource/$version/meta/data.csv")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"use_resource/$version/meta/data.csv\"")
+
+    }
+
+    @Test
+    fun `gets resource file with space in name`()
+    {
+        val version = File("${AppConfig()["orderly.root"]}/archive/spaces/").list()[0]
+
+        val resourceEncoded = "a+resource+with+spaces.csv"
+        val url = "/reports/spaces/versions/$version/resources/$resourceEncoded/"
+
+
+        val testresponse = requestHelper.get("/reports/spaces/versions/$version/", user = requestHelper.fakeReviewer)
+
+        assertSuccessful(testresponse)
+
+        val token = requestHelper.generateOnetimeToken(url)
+        val response = requestHelper.get("$url?access_token=$token", ContentTypes.binarydata, user = requestHelper.fakeReviewer)
+
+        assertSuccessful(response)
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/octet-stream")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"spaces/$version/a resource with spaces.csv\"")
 
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ArtefactControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ArtefactControllerTests.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonParser
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.doThrow
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -68,6 +69,8 @@ class ArtefactControllerTests : ControllerTest()
         val sut = ArtefactController(actionContext, orderly, fileSystem, mockConfig)
 
         sut.download()
+
+        verify(actionContext).addResponseHeader("Content-Disposition", "attachment; filename=\"testname/testversion/testartefact\"")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ResourceControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/reporting_api/tests/unit_tests/controllers/ResourceControllerTests.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.doThrow
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import com.nhaarman.mockito_kotlin.verify
 import org.vaccineimpact.reporting_api.ActionContext
 import org.vaccineimpact.reporting_api.FileSystem
 import org.vaccineimpact.reporting_api.controllers.ResourceController
@@ -69,6 +70,7 @@ class ResourceControllerTests : ControllerTest()
         val sut = ResourceController(actionContext, orderly, fileSystem, mockConfig)
 
         sut.download()
+        verify(actionContext).addResponseHeader("Content-Disposition", "attachment; filename=\"testname/testversion/testresource\"")
     }
 
     @Test


### PR DESCRIPTION
The original ticket said "can't be dowloaded" but the behaviour I saw in the reportle was that they could be downloaded, but would be saved with the wrong name - up to the first space in the name and with no file suffix. Wrapping the filename in the Content-Disposition header in quotes is the fix for this, though it's difficult to test in automated tests, other than that the header is as expected. 

Once you're happy with this branch then please punt the ticket back to me and I'll add the fix to OrderlyWeb too. 

 I stuffed up the original branch and thought it would be easier to just start a new one, hence odd branch name. 